### PR TITLE
LoadingColour PropsType

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,22 @@ This will result in:
   <img src="example.png" alt="">
 </div>
 
-See [the propTypes](index.js) for additional info. 
+## Props
+
+Prop | Description | Type | Defualt
+------ | ------ | ------ | ------
+**`containerStyle`** | Array Container Styles | Array |  **`{}`**
+**`backgroundColor`** | String for Background color of View Finder. | String | **`transparent`**
+**`color`** | String for Color of the View finder edges | String | **`#FFF`**
+**`height`** | Number for Height of View Finder | Number | **`200`**
+**`width`** | Number for Width of View Finder | Number | **`#200`**
+**`borderWidth`** | Number for Border with of View Finder edges | Number | **`3`**
+**`borderRadius`** | Number for Border Radius of View Finder edges | Number | **`0`**
+**`borderLength `** | Number for Border length of View Finder edges | Number | **`25`**
+**`loading`** | Bool for the indicate if loading indicator should be shown | Bool | **`false`**
+**`loadingColor`** | String for Color of the loading indicator | String | **`#FFF`**
+**`loadingBelowVF`** | Bool for the indicate if loading indicator should be shown under View Finder | Bool | **`false`**
+
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const ViewFinder = ({
   color,
   loading,
   loadingBelowVF,
+  loadingColor,
   borderLength
 }) => (
   <View style={[styles.container, containerStyle, { backgroundColor }]}>
@@ -46,7 +47,7 @@ const ViewFinder = ({
         ]}
       />
       {loading && (
-        <ActivityIndicator style={[loadingBelowVF ? { top: (height - 50)}: loadingBelowVF]} animating={loading} color={color} size='large' />
+        <ActivityIndicator style={[loadingBelowVF ? { top: (height - 50)}: loadingBelowVF]} animating={loading} color={loadingColor} size='large' />
       )}
       <View
         style={[
@@ -100,7 +101,7 @@ ViewFinder.propTypes = {
      */
   borderLength: PropTypes.number,
   /**
-     * Color of View finder edges and Spinner
+     * Color of The View finder edges
      */
   color: PropTypes.string,
   /**
@@ -115,6 +116,10 @@ ViewFinder.propTypes = {
      * Bool to indicate if loading indicator should be shown under View Finder
      */
   loadingBelowVF: PropTypes.bool,
+  /**
+     * Color of The Spinner
+     */
+  loadingColor: PropTypes.string,
   /**
      * Width of View Finder
      */
@@ -131,6 +136,7 @@ ViewFinder.defaultProps = {
   height: 200,
   loading: false,
   loadingBelowVF: false,
+  loadingColor: '#fff',
   width: 200
 }
 


### PR DESCRIPTION
Added Ability To Change Spinner Colour

This makes Both the ViewFinder And Spinner Separate,
For the use case that you don't want them both to be the same colour. 

**Example**
`<ViewFinder color={"#00C09C"}  loading={true} loadingColor={'#FFF'} loadingBelowVF={true}/>`
[Example](https://i.imgur.com/EBAyYXo.jpg)